### PR TITLE
TASK-26265 centralise third party libraries versions in maven-depmgt-pom

### DIFF
--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -73,6 +73,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <groupId>commons-fileupload</groupId>
          <artifactId>commons-fileupload</artifactId>
       </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+      </dependency>
    </dependencies>
 
    <build>
@@ -80,7 +84,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>1.5</version>
             <executions>
                <execution>
                   <id>add-test-sources</id>

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/ContainerRequest.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/ContainerRequest.java
@@ -36,13 +36,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.Variant;
 
 /**
  * @author <a href="mailto:andrew00x@gmail.com">Andrey Parfonov</a>
@@ -611,6 +606,19 @@ public class ContainerRequest implements GenericContainerRequest
          }
       }
 
+      return null;
+   }
+  
+   @Override
+   public ResponseBuilder evaluatePreconditions() {
+      List<String> ifMatch = getRequestHeaders().get(HttpHeaders.IF_MATCH);
+      if (ifMatch != null) {
+          for (String value : ifMatch) {
+              if (!"*".equals(value)) {
+                  return Response.status(Response.Status.PRECONDITION_FAILED).tag(EntityTag.valueOf(value));
+              }
+          }
+      }
       return null;
    }
 

--- a/exo.ws.testframework/src/main/java/org/exoplatform/services/test/mock/MockHttpServletRequest.java
+++ b/exo.ws.testframework/src/main/java/org/exoplatform/services/test/mock/MockHttpServletRequest.java
@@ -34,19 +34,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.Part;
+import javax.servlet.*;
+import javax.servlet.http.*;
 
 /**
  * The Class MockHttpServletRequest.
@@ -62,7 +51,7 @@ public class MockHttpServletRequest implements HttpServletRequest
    private String method;
 
    /** Length. */
-   private int length;
+   private long length;
 
    /** Request url. */
    private String requestURL;
@@ -169,7 +158,7 @@ public class MockHttpServletRequest implements HttpServletRequest
     */
    public int getContentLength()
    {
-      return length;
+      return (int) length;
    }
 
    /**
@@ -751,6 +740,21 @@ public class MockHttpServletRequest implements HttpServletRequest
    {
       throw new ServletException("Request is not of type multipart/form-data");
    }
+
+  @Override
+  public long getContentLengthLong() {
+    return length;
+  }
+
+  @Override
+  public String changeSessionId() {
+    return session == null ? null : session.getId();
+  }
+
+  @Override
+  public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+    return null;
+  }
 }
 
 @SuppressWarnings("unchecked")
@@ -790,4 +794,19 @@ class MockServletInputStream extends ServletInputStream
    {
       return data.read();
    }
+
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+
+  @Override
+  public boolean isReady() {
+    return true;
+  }
+
+  @Override
+  public void setReadListener(ReadListener readListener) {
+    // Nothing to do
+  }
 }

--- a/exo.ws.testframework/src/main/java/org/exoplatform/services/test/mock/MockHttpServletResponse.java
+++ b/exo.ws.testframework/src/main/java/org/exoplatform/services/test/mock/MockHttpServletResponse.java
@@ -34,6 +34,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
@@ -83,7 +84,7 @@ public class MockHttpServletResponse implements HttpServletResponse
    private String contentType = null;
 
    /** The content length. */
-   protected int contentLength = -1;
+   protected long contentLength = -1;
 
    /** The encoding. */
    protected String charset = null;
@@ -464,6 +465,16 @@ public class MockHttpServletResponse implements HttpServletResponse
       {
          baos.write(i);
       }
+
+      @Override
+      public boolean isReady() {
+        return true;
+      }
+
+      @Override
+      public void setWriteListener(WriteListener writeListener) {
+        // Nothing to change
+      }
    }
 
    /**
@@ -501,4 +512,9 @@ public class MockHttpServletResponse implements HttpServletResponse
    {
       return Collections.unmodifiableSet(headers.keySet());
    }
+
+  @Override
+  public void setContentLengthLong(long len) {
+    this.contentLength = len;
+  }
 }

--- a/exo.ws.testframework/src/main/java/org/exoplatform/services/test/mock/MockServletContext.java
+++ b/exo.ws.testframework/src/main/java/org/exoplatform/services/test/mock/MockServletContext.java
@@ -598,4 +598,9 @@ public class MockServletContext implements ServletContext
    {
    }
 
+   @Override
+   public String getVirtualServerName() {
+     return null;
+   }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
+      <artifactId>maven-parent-pom</artifactId>
       <groupId>org.exoplatform</groupId>
-      <artifactId>foundation-parent</artifactId>
-      <version>22-M02</version>
+      <version>23-M06</version>
       <relativePath />
    </parent>
 
@@ -36,17 +36,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
    <description>Exoplatform SAS 'Web Services' project.</description>
 
    <scm>
-      <connection>scm:git:git://github.com/exoplatform/ws.git</connection>
-      <developerConnection>scm:git:git@github.com:exoplatform/ws.git</developerConnection>
-      <url>https://fisheye.exoplatform.org/browse/ws-dev</url>
-     <tag>HEAD</tag>
-  </scm>
+      <connection>scm:git:git://github.com/meeds-io/ws.git</connection>
+      <developerConnection>scm:git:git@github.com:meeds-io/ws.git</developerConnection>
+      <url>https://github.com/meeds-io/ws</url>
+      <tag>HEAD</tag>
+   </scm>
 
    <properties>
-      <exo.product.name>exo-ws</exo.product.name>
-      <exo.product.specification>2.4</exo.product.specification>
-
-      <org.exoplatform.kernel.version>6.2.x-SNAPSHOT</org.exoplatform.kernel.version>
       <org.exoplatform.core.version>6.2.x-SNAPSHOT</org.exoplatform.core.version>
    </properties>
 
@@ -62,35 +58,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
    <dependencyManagement>
       <dependencies>
          <dependency>
-            <groupId>org.exoplatform.kernel</groupId>
-            <artifactId>exo.kernel.commons</artifactId>
-            <version>${org.exoplatform.kernel.version}</version>
+           <groupId>org.exoplatform.core</groupId>
+           <artifactId>core-parent</artifactId>
+           <version>${org.exoplatform.core.version}</version>
+           <type>pom</type>
+           <scope>import</scope>
          </dependency>
-         <dependency>
-            <groupId>org.exoplatform.kernel</groupId>
-            <artifactId>exo.kernel.container</artifactId>
-            <version>${org.exoplatform.kernel.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.exoplatform.kernel</groupId>
-            <artifactId>exo.kernel.component.common</artifactId>
-            <version>${org.exoplatform.kernel.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.exoplatform.kernel</groupId>
-            <artifactId>exo.kernel.commons.test</artifactId>
-            <version>${org.exoplatform.kernel.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.exoplatform.core</groupId>
-            <artifactId>exo.core.component.xml-processing</artifactId>
-            <version>${org.exoplatform.core.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.exoplatform.core</groupId>
-            <artifactId>exo.core.component.script.groovy</artifactId>
-            <version>${org.exoplatform.core.version}</version>
-         </dependency>
+
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ws-parent</artifactId>
@@ -127,41 +101,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <groupId>${project.groupId}</groupId>
             <artifactId>exo.ws.frameworks.servlet</artifactId>
             <version>${project.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-         </dependency>
-         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>1.4.7</version>
-         </dependency>
-         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <version>1.3.1</version>
-         </dependency>
-         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-            <version>1.0</version>
-         </dependency>
-         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-            <version>1.0</version>
-         </dependency>
-         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
-         </dependency>
-         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.11</version>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
    <parent>
       <artifactId>maven-parent-pom</artifactId>
       <groupId>org.exoplatform</groupId>
-      <version>23-M06</version>
+      <version>23-M08</version>
       <relativePath />
    </parent>
 


### PR DESCRIPTION
This PR will :
* centralise maven plugin dependencies by changing parent POM to use `maven-parent-pom:org.exoplatform` in order to ease the maintenance and coherence of developed artifacts
* centralise jar dependencies in order to ensure jar versions coherence between all projects and avoid bad jar versions in runtime. This will ease the maintenance and update of jar dependencies as well.
* Add missing servlet-api methods that wasn't defined because the jar version was outdated and wasn't centralized