### PR TITLE
Avoid swallow REST endpoints exceptions

### DIFF
--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DefaultExceptionMapper.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DefaultExceptionMapper.java
@@ -17,8 +17,11 @@
 
 package org.exoplatform.services.rest.impl;
 
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.ExtHttpHeaders;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -33,10 +36,19 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception>
 {
 
    /**
+    * Logger.
+    */
+   private static final Log LOG = ExoLogger.getLogger(DefaultExceptionMapper.class);
+
+   /**
     * {@inheritDoc}
     */
    public Response toResponse(Exception exception)
    {
+      if (!(exception instanceof WebApplicationException || exception.getCause() instanceof WebApplicationException)) {
+        LOG.warn("Uncaught REST Service Exception", exception);
+      }
+
       String message = exception.getMessage();
       return Response.status(500).entity(message == null ? exception.getClass().getName() : message).type(
          MediaType.TEXT_PLAIN).header(ExtHttpHeaders.JAXRS_BODY_PROVIDED, "Error-Message").build();

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
@@ -214,11 +214,6 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
             }
             if (excmap != null)
             {
-               if (LOG.isDebugEnabled())
-               {
-                  // Hide error message if exception mapper exists.
-                  LOG.warn("Internal error occurs.", cause);
-               }
                response.setResponse(excmap.toResponse(e.getCause()));
             }
             else

--- a/exo.ws.rest.core/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/exo.ws.rest.core/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.exoplatform.services.rest.impl.RuntimeDelegateImpl


### PR DESCRIPTION
REST Services doesn't manage unchecked exceptions in general, which leads to have some exceptions swallowed. This change will log all uncaught exceptions except for WebApplicationException which is well handled. In addition, this PR will add a missing configuration file for enabling JAX-RS implementation of eXo in a centralized way