### PR TITLE
Task-46145 : Fix jacoco execution

### DIFF
--- a/exo.ws.commons/pom.xml
+++ b/exo.ws.commons/pom.xml
@@ -58,7 +58,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -87,7 +87,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.ws.rest.ext/pom.xml
+++ b/exo.ws.rest.ext/pom.xml
@@ -78,7 +78,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>${argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>


### PR DESCRIPTION
    Before this fix, jacoco does not fail if target ratio is not reached.
    This is due to the fact that surefire override jacoco argLine and jacoco option are not more usable
    This fix follow this https://stackoverflow.com/questions/12269558/maven-jacoco-plugin-error and re-add ${argLine} in surefire option, so that jacoco is able to find his options