### PR TITLE
Task-54770 : remove header jaxrs-body-provider when a REST request fails

### DIFF
--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/ExtHttpHeaders.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/ExtHttpHeaders.java
@@ -118,13 +118,6 @@ public interface ExtHttpHeaders extends HttpHeaders
     * Headers for Distributed Authoring</a> section 9 for more information.
     */
    public static final String IF = "If";
-   
-   /**
-    * This header indicates that body is provided via JAXR framework.
-    * Value of header MAY contain additional information about the nature
-    * of body's content, for example: 'Error-Message'. 
-    */
-   public static final String JAXRS_BODY_PROVIDED = "JAXRS-Body-Provided";
 
    /**
     * WebDav "Timeout" header. See <a href='http://www.ietf.org/rfc/rfc2518.txt'>

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DefaultExceptionMapper.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DefaultExceptionMapper.java
@@ -51,7 +51,8 @@ public class DefaultExceptionMapper implements ExceptionMapper<Exception>
 
       String message = exception.getMessage();
       return Response.status(500).entity(message == null ? exception.getClass().getName() : message).type(
-         MediaType.TEXT_PLAIN).header(ExtHttpHeaders.JAXRS_BODY_PROVIDED, "Error-Message").build();
+                                                                                                          MediaType.TEXT_PLAIN)
+                     .build();
    }
 
 }

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DefaultExceptionMapper.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DefaultExceptionMapper.java
@@ -19,7 +19,6 @@ package org.exoplatform.services.rest.impl;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.rest.ExtHttpHeaders;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
@@ -23,7 +23,6 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.rest.ExtHttpHeaders;
 import org.exoplatform.services.rest.FilterDescriptor;
 import org.exoplatform.services.rest.GenericContainerRequest;
 import org.exoplatform.services.rest.GenericContainerResponse;
@@ -234,24 +233,6 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
       responseBuilder.entity(message).type(MediaType.TEXT_PLAIN);
       return responseBuilder.build();
    }
-
-   /**
-    * Get JAXR header for response status.
-    * 
-    * @param status response status
-    * @return JAXRS header or null.
-    */
-   private String getJaxrsHeader(int status)
-   {
-      if (status >= 400)
-      {
-         return "Error-Message";
-      }
-      // Add required behavior here.
-      return null;
-   }
-
-   //
 
    /**
     * For writing error message.

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
@@ -142,14 +142,6 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
          try
          {
             dispatcher.dispatch(request, response);
-            if (response.getHttpHeaders().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED) == null)
-            {
-               String jaxrsHeader = getJaxrsHeader(response.getStatus());
-               if (jaxrsHeader != null)
-               {
-                  response.getHttpHeaders().putSingle(ExtHttpHeaders.JAXRS_BODY_PROVIDED, jaxrsHeader);
-               }
-            }
          }
          catch (WebApplicationException e)
          {
@@ -183,17 +175,6 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
                   if (e.getMessage() != null)
                   {
                      errorResponse = createErrorResponse(errorStatus, e.getMessage());
-                  }
-               }
-            }
-            else
-            {
-               if (errorResponse.getMetadata().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED) == null)
-               {
-                  String jaxrsHeader = getJaxrsHeader(errorStatus);
-                  if (jaxrsHeader != null)
-                  {
-                     errorResponse.getMetadata().putSingle(ExtHttpHeaders.JAXRS_BODY_PROVIDED, jaxrsHeader);
                   }
                }
             }
@@ -251,10 +232,6 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
 
       ResponseBuilder responseBuilder = Response.status(status);
       responseBuilder.entity(message).type(MediaType.TEXT_PLAIN);
-      String jaxrsHeader = getJaxrsHeader(status);
-      if (jaxrsHeader != null)
-         responseBuilder.header(ExtHttpHeaders.JAXRS_BODY_PROVIDED, jaxrsHeader);
-
       return responseBuilder.build();
    }
 

--- a/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/ExceptionsTest.java
+++ b/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/ExceptionsTest.java
@@ -112,7 +112,6 @@ public class ExceptionsTest extends BaseTest
       assertEquals(500, response.getStatus());
       String entity = new String(writer.getBody());
       assertEquals(errorMessage, entity);
-      assertNotNull(response.getHttpHeaders().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED));
    }
 
    public void testUncheckedException() throws Exception
@@ -122,7 +121,6 @@ public class ExceptionsTest extends BaseTest
       assertEquals(500, response.getStatus());
       String entity = new String(writer.getBody());
       assertEquals(errorMessage, entity);
-      assertNotNull(response.getHttpHeaders().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED));
    }
 
    public void testWebApplicationExceptionWithCause() throws Exception
@@ -132,7 +130,6 @@ public class ExceptionsTest extends BaseTest
       assertEquals(500, response.getStatus());
       String entity = new String(writer.getBody());
       assertEquals(new Exception(errorMessage).toString(), entity);
-      assertNotNull(response.getHttpHeaders().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED));
    }
 
    public void testWebApplicationExceptionWithoutCause() throws Exception
@@ -141,7 +138,6 @@ public class ExceptionsTest extends BaseTest
       ContainerResponse response = launcher.service("GET", "/a/2", "", null, null, writer, null);
       assertEquals(500, response.getStatus());
       assertNull(response.getEntity());
-      assertNull(response.getHttpHeaders().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED));
    }
 
    public void testWebApplicationExceptionWithResponse() throws Exception
@@ -151,7 +147,6 @@ public class ExceptionsTest extends BaseTest
       assertEquals(500, response.getStatus());
       String entity = new String(writer.getBody());
       assertEquals(errorMessage, entity);
-      assertNotNull(response.getHttpHeaders().getFirst(ExtHttpHeaders.JAXRS_BODY_PROVIDED));
    }
 
    public void testErrorOnRequestLifeCycleEnd() throws Exception


### PR DESCRIPTION
Before this fix, when a rest request fails, the response contain a header name jaxrs-body-provider, which give information about the framework used
As this header is no more necessary, this commit remove it