### PR TITLE
TASK-59178: Create a http PATCH annotation to be used in rest endpoints

### DIFF
--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/http/PATCH.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/http/PATCH.java
@@ -1,0 +1,13 @@
+package org.exoplatform.services.rest.ext.http;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.HttpMethod;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH {
+}


### PR DESCRIPTION
Prior to this change, No Patch annotation exists to be used in rest endpoints with jaxrs1, in fact we're using the swagger jaxrs PATCH annottaion.
This PR should create a new PATCH annotation to be used in our restenpoints instead of the one comes with swagger jaxrs package