### PR TITLE
TASK-59178: Create a http PATCH annotation to be used in rest endpoints

### DIFF
--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/http/PATCH.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/http/PATCH.java
@@ -1,0 +1,31 @@
+/*
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2022 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.services.rest.http;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.HttpMethod;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH {
+}


### PR DESCRIPTION
Prior to this change, No Patch annotation exists to be used in rest endpoints with jaxrs1, in fact we're using the swagger jaxrs PATCH annotation.
This PR should create a new PATCH annotation to be used in our restenpoints instead of the one comes with swagger jaxrs package