### PR TITLE
feat:stabilize WS build failure with jdk 17- EXO-60344

### DIFF
--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -87,7 +87,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>@{argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.lang=ALL-UNNAMED -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>

--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -152,6 +152,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   </configuration>
                </execution>
             </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.glassfish.jaxb</groupId>
+                  <artifactId>jaxb-runtime</artifactId>
+                  <version>2.3.3</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/transport/SerialInputData.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/transport/SerialInputData.java
@@ -178,7 +178,7 @@ public class SerialInputData implements Serializable
           * {@inheritDoc}
           */
          @Override
-         protected void finalize() throws IOException
+         protected void finalize() throws Throwable
          {
             try
             {

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/transport/SerialInputData.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/transport/SerialInputData.java
@@ -173,25 +173,6 @@ public class SerialInputData implements Serializable
                removed = file.delete();
             }
          }
-
-         /**
-          * {@inheritDoc}
-          */
-         @Override
-         protected void finalize() throws Throwable
-         {
-            try
-            {
-               // if file was not removed
-               if (!removed)
-                  file.delete();
-
-            }
-            finally
-            {
-               super.finalize();
-            }
-         }
       };
    }
 


### PR DESCRIPTION
prior to this change, when upgrading to JDK 17 WS throws many exceptions and fails when building: " module java.base does not opens java.lang", " unreported exception java.lang.Throwable; must be caught or declared to be thrown
.". This change will fix these errors.