### PR TITLE
feat:stabilize WS build failure with jdk 17- EXO-60344 - Meeds-io/MIPs#26

### DIFF
--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/IdempotentSequence.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/IdempotentSequence.java
@@ -140,7 +140,7 @@ class IdempotentSequence
     * </OL>
     * <P>
     * The major assumption here is that the side effects of any method only apply
-    * to resource specified. E.g. a <tt>"PUT /barbara.html"</tt> will only affect
+    * to resource specified. E.g. a <code>"PUT /barbara.html"</code> will only affect
     * the resource "/barbara.html" and nothing else. This assumption is violated
     * by POST of course; however, POSTs are not pipelined and will therefore
     * never show up here.

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/Log.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/Log.java
@@ -54,7 +54,7 @@ import java.util.TimeZone;
  * All log entries are preceded by the name of the currently executing thread,
  * enclosed in {}'s, and the current time in hours, minutes, seconds, and
  * milliseconds, enclosed in []'s. Example:
- * <tt>{Thread-5} [20:14:03.244] Conn:  Sending Request</tt>
+ * <code>{Thread-5} [20:14:03.244] Conn:  Sending Request</code>
  * <P>
  * When the class is loaded, two java system properties are read:
  * <var>HTTPClient.log.file</var> and <var>HTTPClient.log.mask</var>. The

--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -87,7 +87,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>@{argLine} ${env.MAVEN_OPTS} -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
+              <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.lang=ALL-UNNAMED -Djava.security.manager=org.exoplatform.commons.test.TestSecurityManager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</argLine>
             </configuration>
          </plugin>
          <plugin>
@@ -152,6 +152,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   </configuration>
                </execution>
             </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.glassfish.jaxb</groupId>
+                  <artifactId>jaxb-runtime</artifactId>
+                  <version>2.3.3</version>
+               </dependency>
+            </dependencies>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/FieldInjectorImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/FieldInjectorImpl.java
@@ -76,7 +76,7 @@ public class FieldInjectorImpl implements FieldInjector
    private final Method setter;
 
    /**
-    * @param resourceClass class that contains field <tt>jfield</tt>
+    * @param resourceClass class that contains field <code>jfield</code>
     * @param jfield java.lang.reflect.Field
     */
    public FieldInjectorImpl(Class<?> resourceClass, java.lang.reflect.Field jfield)

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/header/HeaderParameterParser.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/header/HeaderParameterParser.java
@@ -236,11 +236,11 @@ public class HeaderParameterParser
    }
 
    /**
-    * Check does char array <tt>chs</tt> contains char <tt>c</tt>.
+    * Check does char array <code>chs</code> contains char <code>c</code>.
     * 
     * @param c char
     * @param chs char array
-    * @return true if char array contains character <tt>c</tt>, false otherwise
+    * @return true if char array contains character <code>c</code>, false otherwise
     */
    private boolean checkChar(char c, char[] chs)
    {

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/DataSourceEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/DataSourceEntityProvider.java
@@ -100,7 +100,7 @@ public class DataSourceEntityProvider implements EntityProvider<DataSource>
 
    /**
     * Create DataSource instance dependent entity size. If entity has size less
-    * then <tt>MAX_BUFFER_SIZE</tt> then {@link ByteArrayDataSource} will be
+    * then <code>MAX_BUFFER_SIZE</code> then {@link ByteArrayDataSource} will be
     * created otherwise {@link MimeFileDataSource} will be created.
     * 
     * @param entityStream the {@link InputStream} of the HTTP entity

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/util/UriPatternMap.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/util/UriPatternMap.java
@@ -37,7 +37,7 @@ public class UriPatternMap<V> extends HashMap<UriPattern, List<V>> implements Ex
 
    /**
     * @param uriPattern the key
-    * @return List of Object mapped to specified <tt>uriPattern</tt>. Method
+    * @return List of Object mapped to specified <code>uriPattern</code>. Method
     *         never return null, empty List instead.
     */
    public List<V> getList(UriPattern uriPattern)

--- a/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/provider/FormEntityTest.java
+++ b/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/provider/FormEntityTest.java
@@ -139,7 +139,7 @@ public class FormEntityTest extends BaseTest
       private Iterator<FileItemTester> pattern;
 
       /**
-       * Initialize <tt>pattern</tt>.
+       * Initialize <code>pattern</code>.
        */
       public Resource2()
       {

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/method/filter/MethodAccessFilter.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/method/filter/MethodAccessFilter.java
@@ -42,7 +42,7 @@ public class MethodAccessFilter implements MethodInvokerFilter
 {
 
    /**
-    * Check does <tt>method</tt> contains one on of security annotations
+    * Check does <code>method</code> contains one on of security annotations
     * PermitAll, DenyAll, RolesAllowed.
     *
     * @see PermitAll

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/transport/SerialInputData.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/transport/SerialInputData.java
@@ -173,25 +173,6 @@ public class SerialInputData implements Serializable
                removed = file.delete();
             }
          }
-
-         /**
-          * {@inheritDoc}
-          */
-         @Override
-         protected void finalize() throws IOException
-         {
-            try
-            {
-               // if file was not removed
-               if (!removed)
-                  file.delete();
-
-            }
-            finally
-            {
-               super.finalize();
-            }
-         }
       };
    }
 


### PR DESCRIPTION
prior to this change, when upgrading to JDK 17 WS throws many exceptions and fails when building: " module java.base does not opens java.lang", " unreported exception java.lang.Throwable; must be caught or declared to be thrown .". This change will fix these errors and javaDocs tags
