### PR TITLE
fix: Fix Javascript Content Type Retrieval - MEED-2089 - Meeds-io/meeds#918

### DIFF
--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -33,7 +33,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
    <description>Implementation of REST Core for Exoplatform SAS 'Web Services' project.</description>
 
    <properties>
-      <exo.test.coverage.ratio>0.70</exo.test.coverage.ratio>
+      <exo.test.coverage.ratio>0.73</exo.test.coverage.ratio>
    </properties>
 
    <dependencies>

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JsonpEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JsonpEntityProvider.java
@@ -102,7 +102,12 @@ public class JsonpEntityProvider extends JsonEntityProvider
    @Override
    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
    {
-      return super.isWriteable(type, genericType, annotations, mediaType) || String.class.isAssignableFrom(type);
+     ApplicationContext context = ApplicationContextImpl.getCurrent();
+     if (context == null) {
+       return false;
+     }
+     String callback = context.getQueryParameters().getFirst(JSONP_PARAMETER);
+     return callback != null && (super.isWriteable(type, genericType, annotations, mediaType) || String.class.isAssignableFrom(type));
    }
 
 }

--- a/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/provider/JsonpEntityTest.java
+++ b/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/provider/JsonpEntityTest.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 public class JsonpEntityTest extends BaseTest
 {
+   private static final String JS_FILE_CONTENT = "console.log('Test JS File')";
 
    @Path("/")
    public static class ResourceBook
@@ -79,6 +80,17 @@ public class JsonpEntityTest extends BaseTest
          book2.setSendByPost(true);
          return new Book[]{book1, book2};
       }
+   }
+
+   @Path("/")
+   public static class TextJavascript {
+
+     @GET
+     @Produces("text/javascript")
+     public String m1() {
+       return JS_FILE_CONTENT;
+     }
+
    }
 
    @Path("/")
@@ -149,7 +161,7 @@ public class JsonpEntityTest extends BaseTest
          response = launcher.service("GET", "/", "", h, null, writer, null);
          fail("An IOException is expected as the parameter jsonp has not been set");
       }
-      catch (IOException e)
+      catch (Exception e)
       {
          // expected
       }
@@ -158,7 +170,7 @@ public class JsonpEntityTest extends BaseTest
          response = launcher.service("GET", "/?param=foo", "", h, null, writer, null);
          fail("An IOException is expected as the parameter jsonp has not been set");
       }
-      catch (IOException e)
+      catch (Exception e)
       {
          // expected
       }
@@ -230,6 +242,23 @@ public class JsonpEntityTest extends BaseTest
       assertTrue(book[1].isSendByPost());
 
       unregistry(r2);
+   }
+
+   public void testTextJavascriptReturnText() throws Exception {
+     TextJavascript r2 = new TextJavascript();
+     registry(r2);
+     MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+     h.putSingle("accept", "text/javascript");
+     ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
+
+     ContainerResponse response = launcher.service("GET", "/", "", h, null, writer, null);
+     assertEquals(200, response.getStatus());
+     assertEquals("text/javascript", response.getContentType().toString());
+
+     String js = (String) response.getEntity();
+     assertEquals(JS_FILE_CONTENT, js);
+
+     unregistry(r2);
    }
 
    @SuppressWarnings({"unchecked", "serial"})


### PR DESCRIPTION
Prior to this change, when serving a REST endpoint using content type 'text/javascript', an error was raised. This change will avoid interpreting systematically the javascript content type REST responses as JsonP.