### PR TITLE
fix: Fix Broken Pipe Error Log Level - MEED-2339 - Meeds-io/meeds#1018

### DIFF
--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/servlet/RestServlet.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/servlet/RestServlet.java
@@ -101,7 +101,7 @@ public class RestServlet extends AbstractHttpServlet implements Connector
       }
       catch (Exception e)
       {
-        if (e.getClass().getName().equals("org.apache.catalina.connector.ClientAbortException")) {
+        if (isBrokenPipeError(e)) {
           LOG.debug("Write socket error!", e);
         } else {
           LOG.warn("An error occurred while calling REST endpoint {}, method: {}",
@@ -213,4 +213,15 @@ public class RestServlet extends AbstractHttpServlet implements Connector
     }
     return transactionalServices;
   }
+
+  private boolean isBrokenPipeError(Throwable e) {
+    if ("org.apache.catalina.connector.ClientAbortException".equals(e.getClass().getName())) { // NOSONAR
+      return true;
+    } else if (e.getCause() != null && e.getCause() != e) {
+      return isBrokenPipeError(e.getCause());
+    } else {
+      return false;
+    }
+  }
+
 }


### PR DESCRIPTION
This change will check for 'Broken Pipe' Nested Exceptions to apply the right LOG Level to it in order to not pollute Prod Logs as defined in https://github.com/Meeds-io/ws/commit/3761edff081635af95606e49cee72857b0d5033b before.