### PR TITLE
fix: Update to JDK21 - EXO-71474 - meeds-io/MIPs#91

### DIFF
--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/Codecs.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/Codecs.java
@@ -32,8 +32,6 @@
 
 package org.exoplatform.common.http.client;
 
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
-
 import java.io.BufferedReader;
 import java.io.EOFException;
 import java.io.File;
@@ -285,7 +283,7 @@ public class Codecs
       int line_len = 45; // line length, in octets
 
       int sidx, didx;
-      char nl[] = PrivilegedSystemHelper.getProperty("line.separator", "\n").toCharArray(), dest[] =
+      char nl[] = System.getProperty("line.separator", "\n").toCharArray(), dest[] =
          new char[(data.length + 2) / 3 * 4 + ((data.length + line_len - 1) / line_len) * (nl.length + 1)];
 
       // split into lines, adding line-length and line terminator
@@ -416,7 +414,7 @@ public class Codecs
          return null;
 
       char map[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'}, nl[] =
-         PrivilegedSystemHelper.getProperty("line.separator", "\n").toCharArray(), res[] =
+         System.getProperty("line.separator", "\n").toCharArray(), res[] =
          new char[(int)(str.length() * 1.5)], src[] =
          str.toCharArray();
       char ch;
@@ -501,7 +499,7 @@ public class Codecs
          return null;
 
       char res[] = new char[(int)(str.length() * 1.1)], src[] = str.toCharArray(), nl[] =
-         PrivilegedSystemHelper.getProperty("line.separator", "\n").toCharArray();
+          System.getProperty("line.separator", "\n").toCharArray();
       int last = 0, didx = 0, slen = str.length();
 
       for (int sidx = 0; sidx < slen;)

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/CookieModule.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/CookieModule.java
@@ -32,7 +32,6 @@
 
 package org.exoplatform.common.http.client;
 
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -213,7 +212,7 @@ public class CookieModule implements HTTPClientModule
 
       try
       {
-         file = PrivilegedSystemHelper.getProperty("HTTPClient.cookies.jar");
+         file = System.getProperty("HTTPClient.cookies.jar");
       }
       catch (Exception e)
       {
@@ -227,19 +226,19 @@ public class CookieModule implements HTTPClientModule
       {
          // default to something reasonable
 
-         String os = PrivilegedSystemHelper.getProperty("os.name");
+         String os = System.getProperty("os.name");
          if (os.equalsIgnoreCase("Windows 95") || os.equalsIgnoreCase("16-bit Windows")
             || os.equalsIgnoreCase("Windows"))
          {
-            file = PrivilegedSystemHelper.getProperty("java.home") + File.separator + ".httpclient_cookies";
+            file = System.getProperty("java.home") + File.separator + ".httpclient_cookies";
          }
          else if (os.equalsIgnoreCase("Windows NT"))
          {
-            file = PrivilegedSystemHelper.getProperty("user.home") + File.separator + ".httpclient_cookies";
+            file = System.getProperty("user.home") + File.separator + ".httpclient_cookies";
          }
          else if (os.equalsIgnoreCase("OS/2"))
          {
-            file = PrivilegedSystemHelper.getProperty("user.home") + File.separator + ".httpclient_cookies";
+            file = System.getProperty("user.home") + File.separator + ".httpclient_cookies";
          }
          else if (os.equalsIgnoreCase("Mac OS") || os.equalsIgnoreCase("MacOS"))
          {
@@ -248,7 +247,7 @@ public class CookieModule implements HTTPClientModule
          else
          // it's probably U*IX or VMS
          {
-            file = PrivilegedSystemHelper.getProperty("user.home") + File.separator + ".httpclient_cookies";
+            file = System.getProperty("user.home") + File.separator + ".httpclient_cookies";
          }
       }
 
@@ -671,7 +670,7 @@ class DefaultCookiePolicyHandler implements CookiePolicyHandler
 
       try
       {
-         list = PrivilegedSystemHelper.getProperty("HTTPClient.cookies.hosts.accept");
+         list = System.getProperty("HTTPClient.cookies.hosts.accept");
       }
       catch (Exception e)
       {
@@ -683,7 +682,7 @@ class DefaultCookiePolicyHandler implements CookiePolicyHandler
 
       try
       {
-         list = PrivilegedSystemHelper.getProperty("HTTPClient.cookies.hosts.reject");
+         list = System.getProperty("HTTPClient.cookies.hosts.reject");
       }
       catch (Exception e)
       {

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/DefaultAuthHandler.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/DefaultAuthHandler.java
@@ -32,7 +32,6 @@
 
 package org.exoplatform.common.http.client;
 
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -1518,7 +1517,7 @@ class SimpleAuthPopup implements AuthorizationPrompter
             // prefill the user field with the username
             try
             {
-               user.setText(PrivilegedSystemHelper.getProperty("user.name", ""));
+               user.setText(System.getProperty("user.name", ""));
                user_focus = false;
             }
             catch (SecurityException se)
@@ -1633,7 +1632,7 @@ class SimpleAuthPrompt implements AuthorizationPrompter
     */
    private static void echo(boolean on)
    {
-      String os = PrivilegedSystemHelper.getProperty("os.name");
+      String os = System.getProperty("os.name");
       String[] cmd = null;
 
       if (os.equalsIgnoreCase("Windows 95") || os.equalsIgnoreCase("Windows NT"))
@@ -1670,7 +1669,7 @@ class SimpleAuthPrompt implements AuthorizationPrompter
     */
    static boolean canUseCLPrompt()
    {
-      String os = PrivilegedSystemHelper.getProperty("os.name");
+      String os = System.getProperty("os.name");
 
       return (os.indexOf("Linux") >= 0 || os.indexOf("SunOS") >= 0 || os.indexOf("Solaris") >= 0
          || os.indexOf("BSD") >= 0 || os.indexOf("AIX") >= 0 || os.indexOf("HP-UX") >= 0 || os.indexOf("IRIX") >= 0

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/HTTPConnection.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/HTTPConnection.java
@@ -33,11 +33,9 @@
 package org.exoplatform.common.http.client;
 
 import org.exoplatform.commons.utils.ClassLoading;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
-import java.applet.Applet;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.FilterOutputStream;
@@ -317,7 +315,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
       try
       // JDK 1.1 naming
       {
-         String host = PrivilegedSystemHelper.getProperty("http.proxyHost");
+         String host = System.getProperty("http.proxyHost");
          if (host == null)
             throw new Exception(); // try JDK 1.0.x naming
          int port = Integer.getInteger("http.proxyPort", -1).intValue();
@@ -336,7 +334,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
          {
             if (Boolean.getBoolean("proxySet"))
             {
-               String host = PrivilegedSystemHelper.getProperty("proxyHost");
+               String host = System.getProperty("proxyHost");
                int port = Integer.getInteger("proxyPort", -1).intValue();
 
                if (LOG.isDebugEnabled())
@@ -358,10 +356,10 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
        */
       try
       {
-         String hosts = PrivilegedSystemHelper.getProperty("HTTPClient.nonProxyHosts");
+         String hosts = System.getProperty("HTTPClient.nonProxyHosts");
          if (hosts == null)
          {
-            hosts = PrivilegedSystemHelper.getProperty("http.nonProxyHosts");
+            hosts = System.getProperty("http.nonProxyHosts");
          }
 
          String[] list = Util.splitProperty(hosts);
@@ -383,7 +381,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
        */
       try
       {
-         String host = PrivilegedSystemHelper.getProperty("HTTPClient.socksHost");
+         String host = System.getProperty("HTTPClient.socksHost");
          if (host != null && host.length() > 0)
          {
             int port = Integer.getInteger("HTTPClient.socksPort", -1).intValue();
@@ -432,7 +430,7 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
       boolean in_applet = false;
       try
       {
-         modules = PrivilegedSystemHelper.getProperty("HTTPClient.Modules", modules);
+         modules = System.getProperty("HTTPClient.Modules", modules);
       }
       catch (SecurityException se)
       {
@@ -562,8 +560,8 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
        */
       try
       {
-         if (PrivilegedSystemHelper.getProperty("os.name").indexOf("Windows") >= 0
-            && PrivilegedSystemHelper.getProperty("java.version").startsWith("1.1"))
+         if (System.getProperty("os.name").indexOf("Windows") >= 0
+            && System.getProperty("java.version").startsWith("1.1"))
          {
             haveMSLargeWritesBug = true;
          }
@@ -611,15 +609,6 @@ public class HTTPConnection implements GlobalConstants, HTTPClientModuleConstant
 
    // Constructors
 
-   /**
-    * Constructs a connection to the host from where the applet was loaded. Note
-    * that current security policies only let applets connect home.
-    * @param applet the current applet
-    */
-   public HTTPConnection(Applet applet) throws ProtocolNotSuppException
-   {
-      this(applet.getCodeBase().getProtocol(), applet.getCodeBase().getHost(), applet.getCodeBase().getPort());
-   }
 
    /**
     * Constructs a connection to the specified host on port 80

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/HTTPResponse.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/HTTPResponse.java
@@ -32,7 +32,6 @@
 
 package org.exoplatform.common.http.client;
 
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -662,7 +661,7 @@ public class HTTPResponse implements HTTPClientModuleConstants
          }
       }
 
-      String nl = PrivilegedSystemHelper.getProperty("line.separator", "\n");
+      String nl = System.getProperty("line.separator", "\n");
 
       StringBuffer str = new StringBuffer(Version);
       str.append(' ');

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/HttpURLConnection.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/HttpURLConnection.java
@@ -33,7 +33,6 @@
 package org.exoplatform.common.http.client;
 
 import org.exoplatform.commons.utils.ClassLoading;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -179,7 +178,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection
       // Set the User-Agent if the http.agent property is set
       try
       {
-         String agent = PrivilegedSystemHelper.getProperty("http.agent");
+         String agent = System.getProperty("http.agent");
          if (agent != null)
             setDefaultRequestProperty("User-Agent", agent);
       }
@@ -214,7 +213,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection
       // first read proxy properties and set
       try
       {
-         String hosts = PrivilegedSystemHelper.getProperty("http.nonProxyHosts", "");
+         String hosts = System.getProperty("http.nonProxyHosts", "");
          if (!hosts.equalsIgnoreCase(non_proxy_hosts))
          {
             connections.clear();
@@ -238,7 +237,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection
 
       try
       {
-         String host = PrivilegedSystemHelper.getProperty("http.proxyHost", "");
+         String host = System.getProperty("http.proxyHost", "");
          int port = Integer.getInteger("http.proxyPort", -1).intValue();
          if (!host.equalsIgnoreCase(proxy_host) || port != proxy_port)
          {

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/Log.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/Log.java
@@ -32,7 +32,6 @@
 
 package org.exoplatform.common.http.client;
 
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 
 import java.io.ByteArrayOutputStream;
@@ -106,7 +105,7 @@ public class Log
    /** All the facilities - for use in <code>setLogging</code> (-1) */
    public static final int ALL = ~0;
 
-   private static final String NL = PrivilegedSystemHelper.getProperty("line.separator");
+   private static final String NL = System.getProperty("line.separator");
 
    private static final long TZ_OFF;
 
@@ -125,7 +124,7 @@ public class Log
 
       try
       {
-         String file = PrivilegedSystemHelper.getProperty("HTTPClient.log.file");
+         String file = System.getProperty("HTTPClient.log.file");
          if (file != null)
          {
             try

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/SocksClient.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/SocksClient.java
@@ -31,8 +31,6 @@
  */
 
 package org.exoplatform.common.http.client;
-
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -293,7 +291,7 @@ class SocksClient
          String user_str;
          try
          {
-            user_str = PrivilegedSystemHelper.getProperty("user.name", "");
+            user_str = System.getProperty("user.name", "");
          }
          catch (SecurityException se)
          {

--- a/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/URI.java
+++ b/exo.ws.commons/src/main/java/org/exoplatform/common/http/client/URI.java
@@ -32,8 +32,6 @@
 
 package org.exoplatform.common.http.client;
 
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.BitSet;
@@ -1783,7 +1781,7 @@ public class URI
       System.err.println("*** Tests finished successfuly"); //NOSONAR
    }
 
-   private static final String nl = PrivilegedSystemHelper.getProperty("line.separator");
+   private static final String nl = System.getProperty("line.separator");
 
    private static void testParser(URI base, String relURI, String result) throws Exception
    {

--- a/exo.ws.frameworks.json/src/main/java/org/exoplatform/ws/frameworks/json/impl/JsonGeneratorImpl.java
+++ b/exo.ws.frameworks.json/src/main/java/org/exoplatform/ws/frameworks/json/impl/JsonGeneratorImpl.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.ws.frameworks.json.impl;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.ws.frameworks.json.JsonGenerator;
 import org.exoplatform.ws.frameworks.json.impl.JsonUtils.Types;
 import org.exoplatform.ws.frameworks.json.value.JsonValue;
@@ -34,7 +33,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -386,13 +384,7 @@ public class JsonGeneratorImpl implements JsonGenerator
    {
       Set<String> set = new HashSet<String>();
       
-      Field[] fields = SecurityHelper.doPrivilegedAction(new PrivilegedAction<Field[]>()
-      {
-         public Field[] run()
-         {
-            return clazz.getDeclaredFields();
-         }
-      });
+      Field[] fields = clazz.getDeclaredFields();
 
       for (Field f : fields)
       {

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/BaseObjectModel.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/BaseObjectModel.java
@@ -16,14 +16,12 @@
  */
 package org.exoplatform.services.rest;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.rest.impl.ConstructorDescriptorImpl;
 import org.exoplatform.services.rest.impl.FieldInjectorImpl;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,13 +49,7 @@ public abstract class BaseObjectModel implements ObjectModel
       this.fields = new ArrayList<FieldInjector>();
       if (scope == ComponentLifecycleScope.PER_REQUEST)
       {
-         Constructor<?>[] jConstructors = 
-            SecurityHelper.doPrivilegedAction(new PrivilegedAction<Constructor<?>[]>() {
-               public Constructor<?>[] run()
-               {
-                  return BaseObjectModel.this.clazz.getConstructors();
-               }
-            });
+         Constructor<?>[] jConstructors = BaseObjectModel.this.clazz.getConstructors();
          for (Constructor<?> constructor : jConstructors)
          {
             constructors.add(new ConstructorDescriptorImpl(clazz, constructor));
@@ -73,13 +65,7 @@ public abstract class BaseObjectModel implements ObjectModel
             Collections.sort(constructors, ConstructorDescriptorImpl.CONSTRUCTOR_COMPARATOR);
          }
          // process field
-         java.lang.reflect.Field[] jfields =
-            SecurityHelper.doPrivilegedAction(new PrivilegedAction<java.lang.reflect.Field[]>() {
-               public java.lang.reflect.Field[] run()
-               {
-                  return BaseObjectModel.this.clazz.getDeclaredFields();
-               }
-            });
+         java.lang.reflect.Field[] jfields = BaseObjectModel.this.clazz.getDeclaredFields();
          for (java.lang.reflect.Field jfield : jfields)
          {
             fields.add(new FieldInjectorImpl(clazz, jfield));

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DependencySupplier.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/DependencySupplier.java
@@ -17,7 +17,6 @@
 package org.exoplatform.services.rest.impl;
 
 import org.exoplatform.commons.utils.ClassLoading;
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
@@ -29,8 +28,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Iterator;
 import java.util.List;
 
@@ -71,18 +68,12 @@ public class DependencySupplier
          final ValueParam injectAnnotationParameter = params.getValueParam("inject.annotation.class");
          try
          {
-            injectAnnotationClass = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Class>()
-            {
-               public Class run() throws ClassNotFoundException
-               {
-                  return ClassLoading.loadClass(injectAnnotationParameter.getValue(), DependencySupplier.class);
-               }
-            });
+            injectAnnotationClass =
+                (Class<? extends Annotation>) ClassLoading.loadClass(injectAnnotationParameter.getValue(), DependencySupplier.class);
          }
-         catch (PrivilegedActionException pe)
+         catch (ClassNotFoundException e)
          {
-            ClassNotFoundException c = (ClassNotFoundException)pe.getCause();
-            throw new RuntimeException(c.getMessage(), c);
+            throw new RuntimeException(e.getMessage(), e);
          }
       }
       if (injectAnnotationClass == null)
@@ -180,19 +171,12 @@ public class DependencySupplier
       Type injectedType = null;
       try
       {
-         get = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Method>()
-         {
-            public Method run() throws NoSuchMethodException
-            {
-               return providerClass.getMethod("get");
-            }
-         });
+         get = providerClass.getMethod("get");
       }
-      catch (PrivilegedActionException pe)
+      catch (NoSuchMethodException e)
       {
-         NoSuchMethodException c = (NoSuchMethodException)pe.getCause();
          // Should never happen since class implements javax.inject.Provider.
-         throw new RuntimeException(c.getMessage(), c);
+         throw new RuntimeException(e.getMessage(), e);
       }
 
       if (get != null)

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/FieldInjectorImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/FieldInjectorImpl.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.ApplicationContext;
@@ -31,9 +30,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.List;
 
 import javax.ws.rs.DefaultValue;
@@ -142,16 +138,11 @@ public class FieldInjectorImpl implements FieldInjector
       Method setter = null;
       try
       {
-         setter = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Method>() {
-            public Method run() throws NoSuchMethodException
-            {
-               String name = jfield.getName();
-               String setterName = "set" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
-               return clazz.getMethod(setterName, jfield.getType());
-            }
-         });
+         String name = jfield.getName();
+         String setterName = "set" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
+         setter = clazz.getMethod(setterName, jfield.getType());
       }
-      catch (PrivilegedActionException e)
+      catch (NoSuchMethodException e)
       {
          if (LOG.isTraceEnabled())
          {
@@ -235,13 +226,7 @@ public class FieldInjectorImpl implements FieldInjector
             {
                if (!Modifier.isPublic(jfield.getModifiers()))
                {
-                  SecurityHelper.doPrivilegedAction(new PrivilegedAction<Void>() {
-                     public Void run()
-                     {
-                        jfield.setAccessible(true);
-                        return null;
-                     }
-                  });
+                  jfield.setAccessible(true);
                }
                jfield.set(resource, pr.resolve(this, context));
             }
@@ -271,13 +256,7 @@ public class FieldInjectorImpl implements FieldInjector
                {
                   if (!Modifier.isPublic(jfield.getModifiers()))
                   {
-                     SecurityHelper.doPrivilegedAction(new PrivilegedAction<Void>() {
-                        public Void run()
-                        {
-                           jfield.setAccessible(true);
-                           return null;
-                        }
-                     });
+                     jfield.setAccessible(true);
                   }
                   jfield.set(resource, tmp);
                }

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/RequestHandlerImpl.java
@@ -16,8 +16,6 @@
  */
 package org.exoplatform.services.rest.impl;
 
-import org.exoplatform.commons.utils.PrivilegedFileHelper;
-import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.container.component.ComponentPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
@@ -199,7 +197,7 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
             else
             {
                LOG.error("Internal error occurs.", cause);
-               throw new UnhandledException(e.getCause());
+               throw new UnhandledException(cause.getCause());
             }
          }
 
@@ -282,16 +280,16 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
    {
       String tmpDirName = properties.get(WS_RS_TMP_DIR);
       File tmpDir = new File(tmpDirName);
-      if (!PrivilegedFileHelper.exists(tmpDir))
+      if (!tmpDir.exists())
       {
          return;
       }
-      File[] files = PrivilegedFileHelper.listFiles(tmpDir);
+      File[] files = tmpDir.listFiles();
       for (File file : files)
       {
-         if (PrivilegedFileHelper.exists(file))
+         if (file.exists())
          {
-            PrivilegedFileHelper.delete(file);
+            file.delete();
          }
       }
    }
@@ -308,7 +306,7 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
       String tmpDirName = properties.get(WS_RS_TMP_DIR);
       if (tmpDirName == null)
       {
-         tmpDir = new File(PrivilegedSystemHelper.getProperty("java.io.tmpdir") + File.separator + "ws_jaxrs");
+         tmpDir = new File(System.getProperty("java.io.tmpdir") + File.separator + "ws_jaxrs");
          properties.put(WS_RS_TMP_DIR, tmpDir.getPath());
       }
       else
@@ -316,9 +314,9 @@ public final class RequestHandlerImpl implements RequestHandler, Startable
          tmpDir = new File(tmpDirName);
       }
 
-      if (!PrivilegedFileHelper.exists(tmpDir))
+      if (!tmpDir.exists())
       {
-         PrivilegedFileHelper.mkdirs(tmpDir);
+         tmpDir.mkdirs();
       }
    }
 

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/ResourceBinder.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/ResourceBinder.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.log.ExoLogger;
@@ -35,7 +34,6 @@ import org.exoplatform.services.rest.resource.ResourceDescriptorVisitor;
 import org.exoplatform.services.rest.uri.UriPattern;
 import org.picocontainer.Startable;
 
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -204,14 +202,7 @@ public class ResourceBinder implements Startable
       this.invokerFactory = invokerFactory;
       // Initialize RuntimeDelegate instance
       // This is first component in life cycle what needs.
-      SecurityHelper.doPrivilegedAction(new PrivilegedAction<Void>()
-      {
-         public Void run()
-         {
-            RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
-            return null;
-         }
-      });
+     RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
 
       rd = RuntimeDelegate.getInstance();
       container = containerContext.getContainer();

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/method/DefaultMethodInvoker.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/method/DefaultMethodInvoker.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl.method;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.ApplicationContext;
@@ -30,8 +29,6 @@ import org.exoplatform.services.rest.resource.GenericMethodResource;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.List;
 
 import javax.ws.rs.MatrixParam;
@@ -185,17 +182,10 @@ public class DefaultMethodInvoker implements MethodInvoker
    {
       try
       {
-         return SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Object>()
-         {
-            public Object run() throws Exception
-            {
-               return methodResource.getMethod().invoke(resource, p);
-            }
-         });
+         return methodResource.getMethod().invoke(resource, p);
       }
-      catch (PrivilegedActionException pae)
+      catch (Exception cause)
       {
-         Throwable cause = pae.getCause();
          if (cause instanceof IllegalArgumentException)
          {
             // should not be thrown

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/method/ParameterHelper.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/method/ParameterHelper.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl.method;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.rest.Property;
 import org.exoplatform.services.rest.method.TypeProducer;
 
@@ -26,8 +25,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -262,17 +259,11 @@ public class ParameterHelper
    {
       try
       {
-         Method method = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Method>()
-         {
-            public Method run() throws Exception
-            {
-               return clazz.getDeclaredMethod("valueOf", String.class);
-            }
-         });
+         Method method = clazz.getDeclaredMethod("valueOf", String.class);
 
          return Modifier.isStatic(method.getModifiers()) ? method : null;
       }
-      catch (PrivilegedActionException e)
+      catch (NoSuchMethodException e)
       {
          return null;
       }

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/DOMSourceEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/DOMSourceEntityProvider.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
+import javax.security.sasl.SaslException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -43,7 +44,6 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.provider.EntityProvider;
@@ -92,17 +92,11 @@ public class DOMSourceEntityProvider implements EntityProvider<DOMSource>
    {
       try
       {
-         Document d = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Document>()
-         {
-            public Document run() throws Exception
-            {
-               return DB.parse(entityStream);
-            }
-         });
+         Document d = DB.parse(entityStream);
 
          return new DOMSource(d);
       }
-      catch (PrivilegedActionException pae)
+      catch (SAXException pae)
       {
          Throwable cause = pae.getCause();
          if (cause instanceof SAXParseException)

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/FileEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/FileEntityProvider.java
@@ -16,10 +16,11 @@
  */
 package org.exoplatform.services.rest.impl.provider;
 
-import org.exoplatform.commons.utils.PrivilegedFileHelper;
 import org.exoplatform.services.rest.provider.EntityProvider;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -52,8 +53,8 @@ public class FileEntityProvider implements EntityProvider<File>
    public File readFrom(Class<File> type, Type genericType, Annotation[] annotations, MediaType mediaType,
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException
    {
-      File f = PrivilegedFileHelper.createTempFile("ws_rs", "tmp");
-      OutputStream out = PrivilegedFileHelper.fileOutputStream(f);
+      File f = File.createTempFile("ws_rs", "tmp");
+      OutputStream out = new FileOutputStream(f);
       try
       {
          IOHelper.write(entityStream, out);
@@ -87,7 +88,7 @@ public class FileEntityProvider implements EntityProvider<File>
    public void writeTo(File t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
       MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException
    {
-      InputStream in = PrivilegedFileHelper.fileInputStream(t);
+      InputStream in = new FileInputStream(t);
       try
       {
          IOHelper.write(in, entityStream);

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JAXBContextResolver.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JAXBContextResolver.java
@@ -16,14 +16,11 @@
  */
 package org.exoplatform.services.rest.impl.provider;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.component.ComponentPlugin;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.impl.header.MediaTypeHelper;
 
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -81,15 +78,9 @@ public class JAXBContextResolver implements ContextResolver<JAXBContextResolver>
       {
          try
          {
-            jaxbctx = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<JAXBContext>()
-            {
-               public JAXBContext run() throws Exception
-               {
-                  return JAXBContext.newInstance(clazz);
-               }
-            });
+            jaxbctx = JAXBContext.newInstance(clazz);
          }
-         catch (PrivilegedActionException pae)
+         catch (JAXBException pae)
          {
             Throwable cause = pae.getCause();
             if (cause instanceof JAXBException)
@@ -129,15 +120,9 @@ public class JAXBContextResolver implements ContextResolver<JAXBContextResolver>
 
       try
       {
-         jaxbctx = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<JAXBContext>()
-         {
-            public JAXBContext run() throws Exception
-            {
-               return JAXBContext.newInstance(clazz);
-            }
-         });
+         jaxbctx = JAXBContext.newInstance(clazz);
       }
-      catch (PrivilegedActionException pae)
+      catch (JAXBException pae)
       {
          Throwable cause = pae.getCause();
          if (cause instanceof JAXBException)

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JAXBElementEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JAXBElementEntityProvider.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl.provider;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.provider.EntityProvider;
@@ -27,8 +26,6 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -87,15 +84,9 @@ public class JAXBElementEntityProvider implements EntityProvider<JAXBElement<?>>
       {
          final JAXBContext jaxbctx = getJAXBContext(c, mediaType);
 
-         return SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<JAXBElement<?>>()
-         {
-            public JAXBElement<?> run() throws Exception
-            {
-               return jaxbctx.createUnmarshaller().unmarshal(new StreamSource(entityStream), c);
-            }
-         });
+         return jaxbctx.createUnmarshaller().unmarshal(new StreamSource(entityStream), c);
       }
-      catch (PrivilegedActionException pae)
+      catch (JAXBException pae)
       {
          Throwable cause = pae.getCause();
          if (cause instanceof UnmarshalException)
@@ -123,10 +114,6 @@ public class JAXBElementEntityProvider implements EntityProvider<JAXBElement<?>>
          {
             throw new RuntimeException(cause);
          }
-      }
-      catch (JAXBException e)
-      {
-         throw new IOException("Can't read from input stream " + e, e);
       }
    }
 

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JAXBObjectEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/JAXBObjectEntityProvider.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl.provider;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.impl.header.MediaTypeHelper;
@@ -27,8 +26,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -83,15 +80,9 @@ public class JAXBObjectEntityProvider implements EntityProvider<Object>
       {
          final JAXBContext jaxbctx = getJAXBContext(type, mediaType);
 
-         return SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Object>()
-         {
-            public Object run() throws Exception
-            {
-               return jaxbctx.createUnmarshaller().unmarshal(entityStream);
-            }
-         });
+         return jaxbctx.createUnmarshaller().unmarshal(entityStream);
       }
-      catch (PrivilegedActionException pae)
+      catch (JAXBException pae)
       {
          Throwable cause = pae.getCause();
          if (cause instanceof UnmarshalException)
@@ -119,10 +110,6 @@ public class JAXBObjectEntityProvider implements EntityProvider<Object>
          {
             throw new RuntimeException(cause);
          }
-      }
-      catch (JAXBException e)
-      {
-         throw new IOException("Can't read from input stream " + e, e);
       }
    }
 

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/SAXSourceEntityProvider.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/provider/SAXSourceEntityProvider.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl.provider;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.rest.provider.EntityProvider;
 import org.xml.sax.InputSource;
 
@@ -25,8 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -93,16 +90,9 @@ public class SAXSourceEntityProvider implements EntityProvider<SAXSource>
       final StreamResult out = new StreamResult(entityStream);
       try
       {
-         SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Void>()
-         {
-            public Void run() throws Exception
-            {
-               TransformerFactory.newInstance().newTransformer().transform(t, out);
-               return null;
-            }
-         });
+         TransformerFactory.newInstance().newTransformer().transform(t, out);
       }
-      catch (PrivilegedActionException pae)
+      catch (Exception pae)
       {
          Throwable cause = pae.getCause();
          if (cause instanceof TransformerConfigurationException)

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/resource/AbstractResourceDescriptorImpl.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/resource/AbstractResourceDescriptorImpl.java
@@ -16,7 +16,6 @@
  */
 package org.exoplatform.services.rest.impl.resource;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.BaseObjectModel;
@@ -43,7 +42,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -242,12 +240,7 @@ public class AbstractResourceDescriptorImpl extends BaseObjectModel implements A
    {
       final Class<?> resourceClass = getObjectClass();
 
-      Method[] methods = SecurityHelper.doPrivilegedAction(new PrivilegedAction<Method[]>() {
-         public Method[] run()
-         {
-            return resourceClass.getDeclaredMethods();
-         }
-      });
+      Method[] methods = resourceClass.getDeclaredMethods();
 
       for (Method method : methods)
       {

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/DefaultGroovyResourceLoader.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/DefaultGroovyResourceLoader.java
@@ -19,15 +19,12 @@ package org.exoplatform.services.rest.ext.groovy;
 
 import groovy.lang.GroovyResourceLoader;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -92,23 +89,7 @@ public class DefaultGroovyResourceLoader implements GroovyResourceLoader
    {
       URL resource = null;
       final String ffilename = filename.replace('.', '/') + getSourceFileExtension();
-      try
-      {
-         resource = SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<URL>()
-         {
-            public URL run() throws MalformedURLException
-            {
-               return getResource(ffilename);
-            }
-         });
-      }
-      catch (PrivilegedActionException e)
-      {
-         Throwable cause = e.getCause();
-         // MalformedURLException
-         throw (MalformedURLException)cause;
-      }
-      return resource;
+      return getResource(ffilename);
    }
 
    protected URL getResource(final String filename) throws MalformedURLException

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/ExtendedGroovyClassLoader.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/ExtendedGroovyClassLoader.java
@@ -25,13 +25,11 @@ import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.Phases;
 import org.codehaus.groovy.control.SourceUnit;
-import org.exoplatform.commons.utils.SecurityHelper;
 
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.CodeSource;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -272,23 +270,13 @@ public class ExtendedGroovyClassLoader extends GroovyClassLoader
 
    protected SingleClassCollector createSingleCollector(CompilationUnit unit, SourceUnit sunit)
    {
-      ExtendedInnerLoader loader = SecurityHelper.doPrivilegedAction(new PrivilegedAction<ExtendedInnerLoader>() {
-         public ExtendedInnerLoader run()
-         {
-            return new ExtendedInnerLoader(ExtendedGroovyClassLoader.this);
-         }
-      });
+      ExtendedInnerLoader loader = new ExtendedInnerLoader(ExtendedGroovyClassLoader.this);
       return new SingleClassCollector(loader, unit, sunit);
    }
 
    protected MultipleClassCollector createMultipleCollector(CompilationUnit unit, Set<SourceUnit> setSunit)
    {
-      ExtendedInnerLoader loader = SecurityHelper.doPrivilegedAction(new PrivilegedAction<ExtendedInnerLoader>() {
-         public ExtendedInnerLoader run()
-         {
-            return new ExtendedInnerLoader(ExtendedGroovyClassLoader.this);
-         }
-      });
+      ExtendedInnerLoader loader = new ExtendedInnerLoader(ExtendedGroovyClassLoader.this);
       return new MultipleClassCollector(loader, unit, setSunit);
    }
 

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/GroovyClassLoaderProvider.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/GroovyClassLoaderProvider.java
@@ -18,11 +18,9 @@ package org.exoplatform.services.rest.ext.groovy;
 
 import groovy.lang.GroovyClassLoader;
 
-import org.exoplatform.commons.utils.SecurityHelper;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.PrivilegedAction;
 
 /**
  * Factory of Groovy class loader. It can provide preset GroovyClassLoader
@@ -40,13 +38,7 @@ public class GroovyClassLoaderProvider
 
    public GroovyClassLoaderProvider()
    {
-      this(SecurityHelper.doPrivilegedAction(new PrivilegedAction<ExtendedGroovyClassLoader>()
-      {
-         public ExtendedGroovyClassLoader run()
-         {
-            return new ExtendedGroovyClassLoader(GroovyClassLoaderProvider.class.getClassLoader());
-         }
-      }));
+      this(new ExtendedGroovyClassLoader(GroovyClassLoaderProvider.class.getClassLoader()));
    }
 
    protected GroovyClassLoaderProvider(ExtendedGroovyClassLoader defaultClassLoader)
@@ -83,14 +75,7 @@ public class GroovyClassLoaderProvider
          roots[i] = sources[i].getPath();
 
       final GroovyClassLoader parent = getGroovyClassLoader();
-      ExtendedGroovyClassLoader classLoader =
-         SecurityHelper.doPrivilegedAction(new PrivilegedAction<ExtendedGroovyClassLoader>()
-         {
-            public ExtendedGroovyClassLoader run()
-            {
-               return new ExtendedGroovyClassLoader(parent);
-            }
-         });
+      ExtendedGroovyClassLoader classLoader = new ExtendedGroovyClassLoader(parent);
       classLoader.setResourceLoader(new DefaultGroovyResourceLoader(roots));
       return classLoader;
    }

--- a/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/GroovyJaxrsPublisher.java
+++ b/exo.ws.rest.ext/src/main/java/org/exoplatform/services/rest/ext/groovy/GroovyJaxrsPublisher.java
@@ -22,7 +22,6 @@ import groovy.lang.GroovyCodeSource;
 import groovy.lang.GroovySystem;
 
 import org.codehaus.groovy.control.CompilationFailedException;
-import org.exoplatform.commons.utils.SecurityHelper;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.log.ExoLogger;
@@ -44,9 +43,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException; //NOSONAR
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -218,22 +214,18 @@ public class GroovyJaxrsPublisher
    public void publishPerRequest(final InputStream in, final ResourceId resourceId,
       final MultivaluedMap<String, String> properties, final SourceFolder[] src, final SourceFile[] files)
    {
-      Class<?> rc = SecurityHelper.doPrivilegedAction(new PrivilegedAction<Class<?>>() {
-         public Class<?> run()
-         {
-            try
-            {
-               ExtendedGroovyClassLoader cl =
-                  (src == null) ? classLoaderProvider.getGroovyClassLoader() : classLoaderProvider
-                     .getGroovyClassLoader(src);
-               return cl.parseClass(in, resourceId.getId(), files);
-            }
-            catch (MalformedURLException e)
-            {
-               throw new IllegalArgumentException(e.getMessage(), e);
-            }
-         }
-      });
+      Class<?> rc;
+      try
+      {
+         ExtendedGroovyClassLoader cl =
+             (src == null) ? classLoaderProvider.getGroovyClassLoader() : classLoaderProvider
+                 .getGroovyClassLoader(src);
+         rc = cl.parseClass(in, resourceId.getId(), files);
+      }
+      catch (MalformedURLException e)
+      {
+         throw new IllegalArgumentException(e.getMessage(), e);
+      }
 
       binder.addResource(rc, properties);
       resources.put(resourceId, rc.getAnnotation(Path.class).value());
@@ -517,25 +509,17 @@ public class GroovyJaxrsPublisher
    public void validateResource(final InputStream in, final String name, final SourceFolder[] src,
       final SourceFile[] files) throws MalformedScriptException
    {
-      //Class<?> rc;
       try
       {
-         //rc = 
-         SecurityHelper.doPrivilegedExceptionAction(new PrivilegedExceptionAction<Class<?>>() {
-            public Class<?> run() throws MalformedURLException
-            {
-               ExtendedGroovyClassLoader cl =
-                  (src == null) ? classLoaderProvider.getGroovyClassLoader() : classLoaderProvider
-                     .getGroovyClassLoader(src);
-               return cl.parseClass(in, (name != null && name.length() > 0) ? name : cl.generateScriptName(), files);
-            }
-         });
+         ExtendedGroovyClassLoader cl =
+             (src == null) ? classLoaderProvider.getGroovyClassLoader() : classLoaderProvider
+                 .getGroovyClassLoader(src);
+         cl.parseClass(in, (name != null && name.length() > 0) ? name : cl.generateScriptName(), files);
       }
-      catch (PrivilegedActionException e)
+      catch (MalformedURLException e)
       {
-         Throwable cause = e.getCause();
          // MalformedURLException
-         throw new IllegalArgumentException(cause.getMessage(), e);
+         throw new IllegalArgumentException(e.getMessage(), e);
       }
       catch (CompilationFailedException e)
       {
@@ -690,12 +674,7 @@ public class GroovyJaxrsPublisher
     */
    protected GroovyCodeSource createCodeSource(final URL url) throws IOException
    {
-      GroovyCodeSource gcs = SecurityHelper.doPrivilegedIOExceptionAction(new PrivilegedExceptionAction<GroovyCodeSource>() {
-         public GroovyCodeSource run() throws IOException
-         {
-            return new GroovyCodeSource(url);
-         }
-      });
+      GroovyCodeSource gcs = new GroovyCodeSource(url);
       gcs.setCachable(false);
       return gcs;
    }


### PR DESCRIPTION
Remove usage of SecurityManager as it is deprecated for removal in jdk21 Remove also usage of classes
- SecurityHelper
- PrivilegedSystemHelper
- PrivilegedFileHelper
- SecureList
- SecureSet
- SecureCollections

These classes are here only to use securityManager, and as it is removed, it is no more necessary

Resolves Meeds-io/MIPs#91

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
