### PR TITLE
fix : Prevent WADL documentation to be exposed publicly - MEED-10096 - meeds-io/meeds#3959

### DIFF
--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -80,6 +80,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>io.meeds.core</groupId>
+         <artifactId>exo.core.component.security.core</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>

--- a/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/method/OptionsRequestMethodInvoker.java
+++ b/exo.ws.rest.core/src/main/java/org/exoplatform/services/rest/impl/method/OptionsRequestMethodInvoker.java
@@ -17,13 +17,17 @@
 package org.exoplatform.services.rest.impl.method;
 
 import org.exoplatform.services.rest.ApplicationContext;
+import org.exoplatform.services.rest.impl.ApplicationContextImpl;
 import org.exoplatform.services.rest.impl.header.MediaTypeHelper;
 import org.exoplatform.services.rest.method.MethodInvoker;
 import org.exoplatform.services.rest.resource.GenericMethodResource;
 import org.exoplatform.services.rest.wadl.WadlProcessor;
 import org.exoplatform.services.rest.wadl.research.Application;
 
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 
 /**
  * @author <a href="mailto:andrew00x@gmail.com">Andrey Parfonov</a>
@@ -37,6 +41,17 @@ public class OptionsRequestMethodInvoker implements MethodInvoker
     */
    public Object invokeMethod(Object resource, GenericMethodResource genericMethodResource, ApplicationContext context)
    {
+
+      SecurityContext securityContext = ApplicationContextImpl.getCurrent().getSecurityContext();
+      String role = "users";
+
+      if (!securityContext.isUserInRole(role)) {
+         // user is not in allowed roles
+         throw new WebApplicationException(Response.status(Response.Status.FORBIDDEN).entity(
+             "You do not have access rights to this resource, please contact your administrator. ").type(
+             MediaType.TEXT_PLAIN).build());
+      }
+
       Application wadlApplication =
          new WadlProcessor().process(genericMethodResource.getParentResource(), context.getBaseUri());
       return Response.ok(wadlApplication, MediaTypeHelper.WADL_TYPE).build();

--- a/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/method/OptionsMethodTest.java
+++ b/exo.ws.rest.core/src/test/java/org/exoplatform/services/rest/impl/method/OptionsMethodTest.java
@@ -16,16 +16,22 @@
  */
 package org.exoplatform.services.rest.impl.method;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.exoplatform.services.rest.BaseTest;
+import org.exoplatform.services.rest.impl.EnvironmentContext;
+import org.exoplatform.services.test.mock.MockHttpServletRequest;
+import org.exoplatform.services.test.mock.MockPrincipal;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.security.Principal;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.SecurityContext;
 
 /**
  * Created by The eXo Platform SAS. <br>
@@ -77,9 +83,48 @@ public class OptionsMethodTest extends BaseTest
 
       Resource2 resource2 = new Resource2();
       registry(resource2);
-      assertEquals(200, launcher.service("OPTIONS", "/b", "", null, null, null).getStatus());
-      assertNotNull(launcher.service("OPTIONS", "/b", "", null, null, null).getResponse().getMetadata());
+      assertEquals(403, launcher.service("OPTIONS", "/b", "", null, null, null).getStatus());
 
+
+      EnvironmentContext envctx = new EnvironmentContext();
+      HttpServletRequest httpRequest = new MockHttpServletRequest("/b", null, 0, "OPTIONS", null);
+      envctx.put(HttpServletRequest.class, httpRequest);
+      envctx.put(SecurityContext.class, new MockSecurityContext("john"));
+
+      assertEquals(200, launcher.service("OPTIONS", "/b", "", null, null, envctx).getStatus());
+      assertNotNull(launcher.service("OPTIONS", "/b", "", null, null, envctx).getResponse().getMetadata());
+
+   }
+
+   protected static class MockSecurityContext implements SecurityContext {
+
+      private final String username;
+
+      public MockSecurityContext(String username) {
+         this.username = username;
+      }
+
+      public Principal getUserPrincipal() {
+         return new MockPrincipal(username);
+      }
+
+      public boolean isUserInRole(String role) {
+         if(username == null) {
+            return false;
+         }
+         if (role == null) {
+            return false;
+         }
+         return true;
+      }
+
+      public boolean isSecure() {
+         return false;
+      }
+
+      public String getAuthenticationScheme() {
+         return null;
+      }
    }
 
 }


### PR DESCRIPTION
Before this fix, REST service exposes WADL documentation without authentication This fix ensure to require authentication for this call to prevent information disclosure

Resolves meeds-io/meeds#3959

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
